### PR TITLE
[FIX][TOK26] Exclude api from path redirection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,13 +16,13 @@ services:
     depends_on:
       - db
     entrypoint: ["/bin/sh", "-c", "yarn db:init && yarn dev"]
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3000/api/ping || exit 1"]
-      interval: 60s
-      timeout: 10s
-      retries: 5
-      start_period: 15s
-      start_interval: 5s
+    # healthcheck:
+    #   test: ["CMD-SHELL", "curl -f http://localhost:3000/api/ping || exit 1"]
+    #   interval: 60s
+    #   timeout: 10s
+    #   retries: 5
+    #   start_period: 15s
+    #   start_interval: 5s
   db:
     container_name: haibu_db
     image: postgres:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,13 +16,13 @@ services:
     depends_on:
       - db
     entrypoint: ["/bin/sh", "-c", "yarn db:init && yarn dev"]
-    # healthcheck:
-    #   test: ["CMD-SHELL", "curl -f http://localhost:3000/api/ping || exit 1"]
-    #   interval: 60s
-    #   timeout: 10s
-    #   retries: 5
-    #   start_period: 15s
-    #   start_interval: 5s
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/api/ping || exit 1"]
+      interval: 60s
+      timeout: 10s
+      retries: 5
+      start_period: 15s
+      start_interval: 5s
   db:
     container_name: haibu_db
     image: postgres:latest

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,7 +16,8 @@ export const config = {
     "/(fr|en)/:path*",
 
     // Enable redirects that add missing locales
+    // except for static files and API routes
     // (e.g. `/pathnames` -> `/en/pathnames`)
-    "/((?!_next|_vercel|.*\\..*).*)",
+    "/((?!_next|_vercel|api|.*\\..*).*)",
   ],
 };


### PR DESCRIPTION
## Context
Following [PR-7 (Add translations)](https://github.com/Abbeal-Tokyo/tokyo-haibu-management/pull/7), path redirection has been established, adding translation tag `/en` to the path when missing, in order to enable internationalization.
After this change, APIs was not working anymore, as translation tag was automatically added to their path (causing 404Not Found error).

## Content

- Prevent path redirection for API
- Docker compose: health check -> 🆗 

## Issue
Fixes TOK-26 